### PR TITLE
refactor: Refactor event types to migration types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cccteam/ccc/accesstypes v0.4.1
 	github.com/cccteam/ccc/columnset v0.0.5
 	github.com/cccteam/ccc/patchset v0.2.2
-	github.com/cccteam/httpio v0.6.1
+	github.com/cccteam/httpio v0.6.2
 	github.com/cccteam/spxscan v0.0.3
 	github.com/go-playground/errors/v5 v5.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -646,8 +646,8 @@ github.com/cccteam/ccc/patchset v0.2.2 h1:DTDR8KMLb8ut3WwquVn6vHE0256ciC8sqODCWN
 github.com/cccteam/ccc/patchset v0.2.2/go.mod h1:elmTrBHXQw0xlCgZ26uh3lZzqhCcTKZeCACV4P7syKY=
 github.com/cccteam/ccc/resourceset v0.3.3 h1:T/6HTMIYJwcvtjP6Umy8R9rQMZP1LL2sKR6QrUXyQVE=
 github.com/cccteam/ccc/resourceset v0.3.3/go.mod h1:WRe4vcTTOzwvGCiPcYLBQAIsZMlDrn7+w2YVOAb5YG8=
-github.com/cccteam/httpio v0.6.1 h1:c2JcfpqDINK7GTqFGFFDQiQR9rG7F7pPZfLeAGr4pEw=
-github.com/cccteam/httpio v0.6.1/go.mod h1:/pfKsDUOZ/PDdA3Ojn/za0WniizVrQ19YAirmbo/NKI=
+github.com/cccteam/httpio v0.6.2 h1:VJBVFyyiJIYHmOUiPOB/1IiQn7DMr4GHqiadmTwJyFw=
+github.com/cccteam/httpio v0.6.2/go.mod h1:/pfKsDUOZ/PDdA3Ojn/za0WniizVrQ19YAirmbo/NKI=
 github.com/cccteam/logger v0.1.12 h1:qmNPJKb9wOlTHYN+WUUaOkKM1YxVyXsOusuA2Xp7/tE=
 github.com/cccteam/logger v0.1.12/go.mod h1:sctqFYiCg0KkKszjmAkWV4ynkuHNbFwTdsAPn8IlWh0=
 github.com/cccteam/spxscan v0.0.3 h1:nKlNvD3pahrFWgoSy3WK9srxQN3n8QUuj9jNUEfr3ro=

--- a/types.go
+++ b/types.go
@@ -39,14 +39,14 @@ type DataChangeEvent struct {
 	ChangeSet   string               `spanner:"ChangeSet"`
 }
 
-type Event struct {
+type Mutation struct {
 	TableName   accesstypes.Resource
 	RowStruct   RowStruct
 	PrimaryKeys PrimaryKey
 	PatchSet    *patchset.PatchSet
 }
 
-type DeleteEvent struct {
+type DeleteMutation struct {
 	TableName   accesstypes.Resource
 	RowStruct   RowStruct
 	PrimaryKeys PrimaryKey


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
refactor: Refactor event types to migration types (#26)

refactor!: Changed types `Event` -> `Mutation` and `DeleteEvent` -> `DeleteMutation` (#26)
END_COMMIT_OVERRIDE